### PR TITLE
Add mode-based hero sections

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import NormalHero from './components/NormalHero.jsx'
+import NerdHero from './components/NerdHero.jsx'
 
 function App() {
   const [mode, setMode] = useState('normal')
@@ -9,7 +11,7 @@ function App() {
   }
 
   return (
-    <div className={`min-h-screen transition-colors duration-500 ${isNerd ? 'bg-purple-950 text-lime-300' : 'bg-white text-gray-900'}`}>
+    <div className={`min-h-screen flex flex-col transition-colors duration-500 ${isNerd ? 'bg-purple-950 text-lime-300' : 'bg-white text-gray-900'}`}>
       <header className="sticky top-0 backdrop-blur bg-white/80 shadow flex justify-between items-center p-4 z-10">
         <h1 className="font-bold">React Tailwind</h1>
         <button
@@ -19,8 +21,8 @@ function App() {
           {isNerd ? 'Nerd Mode' : 'Normal Mode'}
         </button>
       </header>
-      <main className="p-4">
-        <p>Welcome to my portfolio!</p>
+      <main className="flex-1">
+        {isNerd ? <NerdHero /> : <NormalHero />}
       </main>
     </div>
   )

--- a/src/components/NerdHero.jsx
+++ b/src/components/NerdHero.jsx
@@ -1,0 +1,11 @@
+import useTypingEffect from '../hooks/useTypingEffect.js'
+
+export default function NerdHero() {
+  const message = 'Welcome to the Nerd Zone'
+  const typed = useTypingEffect(message, 80)
+  return (
+    <section className="h-screen flex items-center justify-center font-mono bg-purple-950 text-lime-300">
+      <pre className="text-lg sm:text-2xl">{typed}<span className="animate-pulse">|</span></pre>
+    </section>
+  )
+}

--- a/src/components/NormalHero.jsx
+++ b/src/components/NormalHero.jsx
@@ -1,0 +1,8 @@
+export default function NormalHero() {
+  return (
+    <section className="h-screen flex flex-col items-center justify-center">
+      <h2 className="text-4xl font-bold">Welcome to my Portfolio</h2>
+      <p className="mt-4 text-lg text-gray-600">Crafting clean experiences</p>
+    </section>
+  )
+}

--- a/src/hooks/useTypingEffect.js
+++ b/src/hooks/useTypingEffect.js
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react'
+
+export default function useTypingEffect(text, speed = 100) {
+  const [displayed, setDisplayed] = useState('')
+
+  useEffect(() => {
+    setDisplayed('')
+    let index = 0
+    const interval = setInterval(() => {
+      index += 1
+      setDisplayed(text.slice(0, index))
+      if (index >= text.length) {
+        clearInterval(interval)
+      }
+    }, speed)
+    return () => clearInterval(interval)
+  }, [text, speed])
+
+  return displayed
+}


### PR DESCRIPTION
## Summary
- show a Normal or Nerd hero section
- animate nerd hero text using a typing effect hook
- wire the hero switch to existing mode state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68493c2330288328a9bb0f2d899626b2