### PR TITLE
Add responsive project grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfolio",
       "version": "0.0.0",
       "dependencies": {
+        "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2524,7 +2525,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2873,6 +2873,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2990,6 +3002,15 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3144,6 +3165,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3174,6 +3206,12 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import NormalHero from './components/NormalHero.jsx'
 import NerdHero from './components/NerdHero.jsx'
+import ProjectGrid from './components/ProjectGrid.jsx'
 
 function App() {
   const [mode, setMode] = useState('normal')
@@ -23,6 +24,7 @@ function App() {
       </header>
       <main className="flex-1">
         {isNerd ? <NerdHero /> : <NormalHero />}
+        <ProjectGrid isNerd={isNerd} />
       </main>
     </div>
   )

--- a/src/components/ProjectGrid.jsx
+++ b/src/components/ProjectGrid.jsx
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types'
+
+const projects = [
+  { title: 'Project One', description: 'An amazing project.' },
+  { title: 'Project Two', description: 'Another fantastic project.' },
+  { title: 'Project Three', description: 'Yet another cool project.' },
+]
+
+export default function ProjectGrid({ isNerd }) {
+  return (
+    <section className="p-6">
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {projects.map((project) => (
+          <article
+            key={project.title}
+            className={`rounded-lg p-6 shadow transition-transform duration-300 transform hover:scale-105 ${
+              isNerd
+                ? 'bg-purple-950 text-lime-300 border border-lime-300'
+                : 'bg-white text-gray-900'
+            }`}
+          >
+            <h3
+              className={`text-xl font-semibold ${isNerd ? 'glitch-text' : ''}`}
+            >
+              {project.title}
+            </h3>
+            <p
+              className={`mt-2 text-sm opacity-80 ${isNerd ? 'glitch-text' : ''}`}
+            >
+              {project.description}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+ProjectGrid.propTypes = {
+  isNerd: PropTypes.bool.isRequired,
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  @keyframes glitch {
+    0% { transform: translate(0); }
+    20% { transform: translate(-2px, 2px); }
+    40% { transform: translate(2px, -2px); }
+    60% { transform: translate(-1px, 1px); }
+    80% { transform: translate(1px, -1px); }
+    100% { transform: translate(0); }
+  }
+
+  .glitch-text {
+    animation: glitch 2s infinite both;
+  }
+}


### PR DESCRIPTION
## Summary
- create `ProjectGrid` component to show cards for projects
- style cards for both Normal and Nerd modes
- integrate project grid into the main app
- add glitch animation utilities
- include `prop-types` dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68493d32e7b08328af0376f024465d02