### PR TITLE
Add Nerd mode GitHub HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Tailwind Layout
 
-This project demonstrates a simple React layout styled with Tailwind CSS. It features a sticky header with a button that toggles between **Normal** and **Nerd** mode. Colors transition smoothly when switching modes, and the entire page animates using **Framer Motion**. Switching to Nerd mode triggers a glitch-style flicker effect.
+This project demonstrates a simple React layout styled with Tailwind CSS. It features a sticky header with a button that toggles between **Normal** and **Nerd** mode. Colors transition smoothly when switching modes, and the entire page animates using **Framer Motion**. Switching to Nerd mode triggers a glitch-style flicker effect and reveals a floating HUD with GitHub statistics.
 
 ## Development
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ const MotionDiv = motion.div
 import NormalHero from './components/NormalHero.jsx'
 import NerdHero from './components/NerdHero.jsx'
 import ProjectGrid from './components/ProjectGrid.jsx'
+import StatsHUD from './components/StatsHUD.jsx'
 
 function App() {
   const [mode, setMode] = useState('normal')
@@ -63,6 +64,7 @@ function App() {
           </main>
         </MotionDiv>
       </AnimatePresence>
+      {isNerd && <StatsHUD />}
     </div>
   )
 }

--- a/src/components/StatsHUD.jsx
+++ b/src/components/StatsHUD.jsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import useTypingEffect from '../hooks/useTypingEffect.js'
+
+export default function StatsHUD() {
+  const username = 'octocat'
+  const [stats, setStats] = useState(null)
+  const typed = useTypingEffect('> Loaded AI_Project', 80)
+
+  useEffect(() => {
+    // Fetch basic GitHub profile stats
+    fetch(`https://api.github.com/users/${username}`)
+      .then((res) => res.json())
+      .then((data) => setStats(data))
+      .catch(() => setStats(null))
+  }, [username])
+
+  // Demo streak counter; replace with real data if available
+  const streak = 5
+
+  return (
+    <aside className="fixed top-4 right-4 bg-purple-950/70 text-lime-300 font-mono p-4 rounded shadow-lg text-glow">
+      <div>{typed}<span className="animate-pulse">|</span></div>
+      {stats && (
+        <ul className="mt-2 text-sm leading-snug">
+          <li>Repos: {stats.public_repos}</li>
+          <li>Followers: {stats.followers}</li>
+          <li>Following: {stats.following}</li>
+        </ul>
+      )}
+      <p className="mt-2 text-sm">Streak: {streak} days</p>
+    </aside>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -16,3 +16,7 @@
     animation: glitch 2s infinite both;
   }
 }
+
+.text-glow {
+  text-shadow: 0 0 6px rgba(163, 230, 53, 0.8);
+}


### PR DESCRIPTION
## Summary
- create StatsHUD to display GitHub stats, streak and log
- show the HUD only in Nerd mode
- style HUD with digital glow
- document the HUD in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68493f7ea1048328a6dae3630851f1fb