### PR TITLE
Add project detail page with ELI5 toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "framer-motion": "^12.16.0",
         "prop-types": "^15.8.1",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1047,6 +1048,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3264,6 +3274,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "framer-motion": "^12.16.0",
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
+import { Routes, Route } from 'react-router-dom'
 
 const MotionDiv = motion.div
 import NormalHero from './components/NormalHero.jsx'
 import NerdHero from './components/NerdHero.jsx'
 import ProjectGrid from './components/ProjectGrid.jsx'
 import StatsHUD from './components/StatsHUD.jsx'
+import ProjectDetail from './components/ProjectDetail.jsx'
 
 function App() {
   const [mode, setMode] = useState('normal')
@@ -59,8 +61,18 @@ function App() {
             </button>
           </header>
           <main className="flex-1">
-            {isNerd ? <NerdHero /> : <NormalHero />}
-            <ProjectGrid isNerd={isNerd} />
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <>
+                    {isNerd ? <NerdHero /> : <NormalHero />}
+                    <ProjectGrid isNerd={isNerd} />
+                  </>
+                }
+              />
+              <Route path="/project/:id" element={<ProjectDetail />} />
+            </Routes>
           </main>
         </MotionDiv>
       </AnimatePresence>

--- a/src/components/ProjectDetail.jsx
+++ b/src/components/ProjectDetail.jsx
@@ -1,0 +1,50 @@
+import { useParams, Link } from 'react-router-dom'
+import { useState } from 'react'
+import { motion as Motion, AnimatePresence } from 'framer-motion'
+import projects from '../data/projects.js'
+
+export default function ProjectDetail() {
+  const { id } = useParams()
+  const project = projects.find((p) => p.id === id)
+
+  const [view, setView] = useState('tech')
+  const toggleView = () => {
+    setView((prev) => (prev === 'tech' ? 'eli5' : 'tech'))
+  }
+
+  if (!project) {
+    return (
+      <section className="p-6 text-center">
+        <p>Project not found.</p>
+        <Link className="underline" to="/">Back to projects</Link>
+      </section>
+    )
+  }
+
+  const description =
+    view === 'tech' ? project.techDescription : project.eli5Description
+
+  return (
+    <section className="p-6 max-w-3xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">{project.title}</h2>
+      <button
+        onClick={toggleView}
+        className="mb-4 px-3 py-1 rounded bg-gray-900 text-white"
+      >
+        {view === 'tech' ? "Explain Like I'm 5" : 'Technical Description'}
+      </button>
+      <AnimatePresence mode="wait">
+        <Motion.p
+          key={view}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.3 }}
+          className="leading-relaxed"
+        >
+          {description}
+        </Motion.p>
+      </AnimatePresence>
+    </section>
+  )
+}

--- a/src/components/ProjectGrid.jsx
+++ b/src/components/ProjectGrid.jsx
@@ -1,10 +1,6 @@
 import PropTypes from 'prop-types'
-
-const projects = [
-  { title: 'Project One', description: 'An amazing project.' },
-  { title: 'Project Two', description: 'Another fantastic project.' },
-  { title: 'Project Three', description: 'Yet another cool project.' },
-]
+import { Link } from 'react-router-dom'
+import projects from '../data/projects.js'
 
 export default function ProjectGrid({ isNerd }) {
   return (
@@ -12,21 +8,17 @@ export default function ProjectGrid({ isNerd }) {
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {projects.map((project) => (
           <article
-            key={project.title}
+            key={project.id}
             className={`rounded-lg p-6 shadow transition-transform duration-300 transform hover:scale-105 ${
               isNerd
                 ? 'bg-purple-950 text-lime-300 border border-lime-300'
                 : 'bg-white text-gray-900'
             }`}
           >
-            <h3
-              className={`text-xl font-semibold ${isNerd ? 'glitch-text' : ''}`}
-            >
-              {project.title}
+            <h3 className={`text-xl font-semibold ${isNerd ? 'glitch-text' : ''}`}>
+              <Link to={`/project/${project.id}`}>{project.title}</Link>
             </h3>
-            <p
-              className={`mt-2 text-sm opacity-80 ${isNerd ? 'glitch-text' : ''}`}
-            >
+            <p className={`mt-2 text-sm opacity-80 ${isNerd ? 'glitch-text' : ''}`}>
               {project.description}
             </p>
           </article>

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1,0 +1,25 @@
+const projects = [
+  {
+    id: 'project-one',
+    title: 'Project One',
+    description: 'An amazing project.',
+    techDescription: 'A detailed overview of Project One, covering its architecture and implementation details.',
+    eli5Description: "Project One is like a set of building blocks that fit together to solve a problem in a fun way.",
+  },
+  {
+    id: 'project-two',
+    title: 'Project Two',
+    description: 'Another fantastic project.',
+    techDescription: 'Project Two uses modern web technologies to deliver responsive user experiences.',
+    eli5Description: "Imagine Project Two as a magic window that shows you exactly what you need without waiting too long.",
+  },
+  {
+    id: 'project-three',
+    title: 'Project Three',
+    description: 'Yet another cool project.',
+    techDescription: 'This project demonstrates efficient state management with advanced hooks.',
+    eli5Description: "Think of Project Three as a clever helper that keeps track of things so you don't have to.",
+  },
+]
+
+export default projects

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add react-router-dom for navigation
- create dataset for projects
- add `ProjectDetail` component with toggle for tech vs ELI5 description
- link ProjectGrid entries to detail pages
- wire up routing in `App` and wrap app in `BrowserRouter`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68494076c7848328902c4b66946a2f1d