### PR TITLE
Add mock terminal with command animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, useNavigate } from 'react-router-dom'
 
 const MotionDiv = motion.div
 import NormalHero from './components/NormalHero.jsx'
@@ -9,11 +9,15 @@ import ProjectGrid from './components/ProjectGrid.jsx'
 import Timeline from './components/Timeline.jsx'
 import StatsHUD from './components/StatsHUD.jsx'
 import ProjectDetail from './components/ProjectDetail.jsx'
+import Terminal from './components/Terminal.jsx'
+import ResumeSection from './components/ResumeSection.jsx'
 
 function App() {
   const [mode, setMode] = useState('normal')
   const [glitch, setGlitch] = useState(false)
+  const [showResume, setShowResume] = useState(false)
   const isNerd = mode === 'nerd'
+  const navigate = useNavigate()
 
   const toggleMode = () => {
     if (isNerd) {
@@ -22,6 +26,23 @@ function App() {
       setGlitch(true)
       setMode('nerd')
     }
+  }
+
+  const handleCommand = (cmd) => {
+    if (cmd.startsWith('run ')) {
+      const id = cmd.slice(4)
+      navigate(`/project/${id}`)
+      return `Running ${id}...`
+    }
+    if (cmd === 'open resume') {
+      setShowResume(true)
+      return 'Opening resume...'
+    }
+    if (cmd === 'close resume') {
+      setShowResume(false)
+      return 'Closing resume...'
+    }
+    return 'Command not found'
   }
 
   useEffect(() => {
@@ -79,6 +100,8 @@ function App() {
         </MotionDiv>
       </AnimatePresence>
       {isNerd && <StatsHUD />}
+      {showResume && <ResumeSection onClose={() => setShowResume(false)} />}
+      {isNerd && <Terminal onCommand={handleCommand} />}
     </div>
   )
 }

--- a/src/components/ResumeSection.jsx
+++ b/src/components/ResumeSection.jsx
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types'
+
+export default function ResumeSection({ onClose }) {
+  return (
+    <section className="p-6 bg-white text-gray-900 max-w-3xl mx-auto" id="resume-section">
+      <h2 className="text-2xl font-bold mb-4">Resume</h2>
+      <p className="mb-4">This is a placeholder for the resume content.</p>
+      <button onClick={onClose} className="px-3 py-1 rounded bg-gray-900 text-white">Close</button>
+    </section>
+  )
+}
+
+ResumeSection.propTypes = {
+  onClose: PropTypes.func.isRequired,
+}

--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -1,0 +1,62 @@
+import { useState, useRef, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import useTypingEffect from '../hooks/useTypingEffect.js'
+
+function TerminalLine({ text, isCommand }) {
+  const typed = useTypingEffect(text, 20)
+  return <div className="whitespace-pre-wrap">{isCommand ? `> ${text}` : typed}</div>
+}
+
+TerminalLine.propTypes = {
+  text: PropTypes.string.isRequired,
+  isCommand: PropTypes.bool.isRequired,
+}
+
+export default function Terminal({ onCommand }) {
+  const [input, setInput] = useState('')
+  const [history, setHistory] = useState([])
+  const containerRef = useRef(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    containerRef.current.scrollTop = containerRef.current.scrollHeight
+  }, [history])
+
+  const runCommand = () => {
+    const cmd = input.trim()
+    if (!cmd) return
+    setHistory((prev) => [...prev, { text: cmd, isCommand: true }])
+    const output = onCommand(cmd)
+    if (output) {
+      setHistory((prev) => [...prev, { text: output, isCommand: false }])
+    }
+    setInput('')
+  }
+
+  const handleKey = (e) => {
+    if (e.key === 'Enter') {
+      runCommand()
+    }
+  }
+
+  return (
+    <div className="terminal" ref={containerRef}>
+      {history.map((item, index) => (
+        <TerminalLine key={index} text={item.text} isCommand={item.isCommand} />
+      ))}
+      <div className="flex">
+        <span>&gt;&nbsp;</span>
+        <input
+          className="flex-1 bg-transparent outline-none"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKey}
+        />
+      </div>
+    </div>
+  )
+}
+
+Terminal.propTypes = {
+  onCommand: PropTypes.func.isRequired,
+}

--- a/src/index.css
+++ b/src/index.css
@@ -28,3 +28,18 @@
   scrollbar-width: none;
 }
 
+@layer components {
+  .terminal {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgb(0 0 0);
+    color: rgb(132 204 22);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    padding: 1rem;
+    max-height: 15rem;
+    overflow-y: auto;
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement a terminal overlay for Nerd mode
- wire commands `run <id>` and `open resume`
- add resume section placeholder
- style terminal component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684942d164e483288d629a26c15221e6