### PR TITLE
Improve responsive layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,11 +75,11 @@ function App() {
           transition={{ duration: 0.3 }}
           className={`min-h-screen flex flex-col transition-colors duration-500 ${isNerd ? 'bg-purple-950 text-lime-300' : 'bg-white text-gray-900'}`}
         >
-          <header className="sticky top-0 backdrop-blur bg-white/80 shadow flex justify-between items-center p-4 z-10">
+          <header className="sticky top-0 backdrop-blur bg-white/80 shadow flex flex-col items-center gap-2 p-4 z-10 sm:flex-row sm:justify-between">
             <h1 className="font-bold">React Tailwind</h1>
             <button
               onClick={toggleMode}
-              className={`px-3 py-1 rounded border transition-colors duration-500 ${isNerd ? 'bg-lime-300 text-purple-950' : 'bg-gray-900 text-white'}`}
+              className={`px-3 py-1 rounded border transition-colors duration-500 w-full sm:w-auto sm:ml-auto ${isNerd ? 'bg-lime-300 text-purple-950' : 'bg-gray-900 text-white'}`}
             >
               {isNerd ? 'Nerd Mode' : 'Normal Mode'}
             </button>

--- a/src/components/NerdHero.jsx
+++ b/src/components/NerdHero.jsx
@@ -4,8 +4,8 @@ export default function NerdHero() {
   const message = 'Welcome to the Nerd Zone'
   const typed = useTypingEffect(message, 80)
   return (
-    <section className="h-screen flex items-center justify-center font-mono bg-purple-950 text-lime-300">
-      <pre className="text-lg sm:text-2xl">{typed}<span className="animate-pulse">|</span></pre>
+    <section className="h-screen flex items-center justify-center px-4 text-center font-mono bg-purple-950 text-lime-300">
+      <pre className="text-base sm:text-2xl">{typed}<span className="animate-pulse">|</span></pre>
     </section>
   )
 }

--- a/src/components/NormalHero.jsx
+++ b/src/components/NormalHero.jsx
@@ -1,8 +1,8 @@
 export default function NormalHero() {
   return (
-    <section className="h-screen flex flex-col items-center justify-center">
-      <h2 className="text-4xl font-bold">Welcome to my Portfolio</h2>
-      <p className="mt-4 text-lg text-gray-600">Crafting clean experiences</p>
+    <section className="h-screen flex flex-col items-center justify-center px-4 text-center">
+      <h2 className="text-3xl sm:text-4xl font-bold">Welcome to my Portfolio</h2>
+      <p className="mt-4 text-base sm:text-lg text-gray-600">Crafting clean experiences</p>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- tweak hero layout for mobile
- adjust Nerd mode hero spacing
- stack header items vertically on small screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849460946508328a4b6808cf336908d