### PR TITLE
Improve responsive grid and HUD

### DIFF
--- a/src/components/ProjectGrid.jsx
+++ b/src/components/ProjectGrid.jsx
@@ -5,7 +5,9 @@ import projects from '../data/projects.js'
 export default function ProjectGrid({ isNerd }) {
   return (
     <section className="p-6">
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div
+        className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+      >
         {projects.map((project) => (
           <article
             key={project.id}

--- a/src/components/StatsHUD.jsx
+++ b/src/components/StatsHUD.jsx
@@ -4,6 +4,7 @@ import useTypingEffect from '../hooks/useTypingEffect.js'
 export default function StatsHUD() {
   const username = 'octocat'
   const [stats, setStats] = useState(null)
+  const [open, setOpen] = useState(false)
   const typed = useTypingEffect('> Loaded AI_Project', 80)
 
   useEffect(() => {
@@ -17,9 +18,12 @@ export default function StatsHUD() {
   // Demo streak counter; replace with real data if available
   const streak = 5
 
-  return (
-    <aside className="fixed top-4 right-4 bg-purple-950/70 text-lime-300 font-mono p-4 rounded shadow-lg text-glow">
-      <div>{typed}<span className="animate-pulse">|</span></div>
+  const hudContent = (
+    <>
+      <div>
+        {typed}
+        <span className="animate-pulse">|</span>
+      </div>
       {stats && (
         <ul className="mt-2 text-sm leading-snug">
           <li>Repos: {stats.public_repos}</li>
@@ -28,6 +32,37 @@ export default function StatsHUD() {
         </ul>
       )}
       <p className="mt-2 text-sm">Streak: {streak} days</p>
-    </aside>
+    </>
+  )
+
+  return (
+    <>
+      <aside className="fixed top-4 right-4 hidden md:block bg-purple-950/70 text-lime-300 font-mono p-4 rounded shadow-lg text-glow z-40">
+        {hudContent}
+      </aside>
+      <button
+        type="button"
+        className="fixed bottom-4 right-4 z-40 rounded-full bg-purple-950 p-3 text-lime-300 shadow md:hidden"
+        onClick={() => setOpen(true)}
+        aria-label="Show stats"
+      >
+        &#x1F4CA;
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 md:hidden">
+          <div className="relative w-11/12 max-w-xs rounded bg-purple-950 p-4 text-lime-300 shadow-lg">
+            <button
+              type="button"
+              className="absolute top-2 right-2"
+              onClick={() => setOpen(false)}
+              aria-label="Close stats"
+            >
+              ✕
+            </button>
+            {hudContent}
+          </div>
+        </div>
+      )}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- ensure ProjectGrid adjusts columns for screen size
- add mobile-friendly button to open StatsHUD
- collapse StatsHUD into modal on small screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849474576608328a8ba99bf1cef122e