### PR TITLE
Add animated ASCII art to Nerd mode

### DIFF
--- a/src/components/AsciiArt.jsx
+++ b/src/components/AsciiArt.jsx
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react'
+
+const frames = [
+  `  /\\_/\\\n ( o.o )\n  > ^ <`,
+  `  /\\_/\\\n ( -.- )\n  > ^ <`,
+]
+
+export default function AsciiArt() {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % frames.length)
+    }, 500)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <pre className="mt-4 text-green-300 text-xs sm:text-sm font-mono leading-none whitespace-pre text-center">
+      {frames[index]}
+    </pre>
+  )
+}

--- a/src/components/NerdHero.jsx
+++ b/src/components/NerdHero.jsx
@@ -1,11 +1,13 @@
 import useTypingEffect from '../hooks/useTypingEffect.js'
+import AsciiArt from './AsciiArt.jsx'
 
 export default function NerdHero() {
   const message = 'Welcome to the Nerd Zone'
   const typed = useTypingEffect(message, 80)
   return (
-    <section className="h-screen flex items-center justify-center px-4 text-center font-mono bg-purple-950 text-lime-300">
+    <section className="h-screen flex flex-col items-center justify-center px-4 text-center font-mono bg-purple-950 text-lime-300">
       <pre className="text-base sm:text-2xl">{typed}<span className="animate-pulse">|</span></pre>
+      <AsciiArt />
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- add an `AsciiArt` component that cycles frames
- show ASCII animation in `NerdHero`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684954eee3788328b411d8af2cdb5db1